### PR TITLE
Try to resolve webview pause issue on iOS

### DIFF
--- a/dist/aframe-firebase-component.js
+++ b/dist/aframe-firebase-component.js
@@ -104,7 +104,7 @@
 	   */
 	  handleEntityAdded: function (id, data) {
 	    // Already added.
-	    if (this.entities[id] || this.broadcastingEntities[id]) { return; }
+	    if (this.entities[id] || this.broadcastingEntities[id] || (localStorage.getItem("entities")&&localStorage.getItem("entities")[id]) ) { return; }
 
 	    // Handle parent-child relationships.
 	    var parentId = data.parentId;
@@ -124,6 +124,7 @@
 	    // Create and reference entity.
 	    var entity = document.createElement('a-entity');
 	    this.entities[id] = entity;
+	    try {sessionStorage.setItem("entities", this.entities);} catch (e) {    if (e == QUOTA_EXCEEDED_ERR) { console.log('Unable to save preferred shirt size.');}}
 
 	    // Components.
 	    Object.keys(data).forEach(function setComponent (componentName) {


### PR DESCRIPTION
The master version failed to delete entities when exiting scene on  iOS safari and webview due to the well know webpage standby on iOS situation. onDisconnect() won't fire when user exit the scene from iOS webviews, this will end up leaving all entities in the firebase database without removing.

http://stackoverflow.com/questions/4940657/handling-standby-on-ipad-using-javascript/4941098#4941098
http://stackoverflow.com/questions/16234185/possible-firebase-bug-with-ondisconnect-when-running-opera
https://groups.google.com/forum/#!topic/firebase-talk/FvzLk0ioP-I

Try to utilize html5 local storage to preserve entity id as a work around so that entity id will be preserved. Thus when user exit and re-enter mobile safari or webview on iOS. Their avatar entity will be resumed rather than creating a new one.

This is a different approach from [#10](https://github.com/ngokevin/aframe-firebase-component/pull/10) However it won't solve the issue when local storage got flushed.